### PR TITLE
Use UI Automation for chat scraping

### DIFF
--- a/WpfApp5/MainWindow.xaml.cs
+++ b/WpfApp5/MainWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace KakaoPcLogger
             InitializeComponent();
 
             _dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data", "kakao_chat_v2.db");
-            _captureService = new ChatCaptureService(new ChatWindowInteractor(), new ClipboardService(), _dbPath);
+            _captureService = new ChatCaptureService(new ChatWindowInteractor(), _dbPath);
 
             LvChats.ItemsSource = _chats;
 
@@ -224,7 +224,7 @@ namespace KakaoPcLogger
                 return;
             }
 
-            string text = result.ClipboardText ?? string.Empty;
+            string text = result.CapturedText ?? string.Empty;
             var now = DateTime.Now;
 
             _captureCount++;

--- a/WpfApp5/Services/ChatCaptureResult.cs
+++ b/WpfApp5/Services/ChatCaptureResult.cs
@@ -3,7 +3,7 @@ namespace KakaoPcLogger.Services
     public sealed class ChatCaptureResult
     {
         public bool Success { get; init; }
-        public string? ClipboardText { get; init; }
+        public string? CapturedText { get; init; }
         public string? Warning { get; init; }
         public string? DbMessage { get; init; }
         public string? DbError { get; init; }

--- a/WpfApp5/Services/ChatWindowInteractor.cs
+++ b/WpfApp5/Services/ChatWindowInteractor.cs
@@ -1,5 +1,7 @@
 using System;
-using System.Threading;
+using System.Collections.Generic;
+using System.Text;
+using System.Windows.Automation;
 using KakaoPcLogger.Interop;
 using KakaoPcLogger.Models;
 
@@ -19,63 +21,231 @@ namespace KakaoPcLogger.Services
             return true;
         }
 
-        public void ActivateAndCopy(ChatEntry entry)
+        public bool TryReadAllText(ChatEntry entry, out string? text, out string? warning)
         {
-            FocusParent(entry.ParentHwnd);
-            SelectAllAndCopy(entry.Hwnd);
-            DeselectList(entry.Hwnd);
+            text = null;
+            warning = null;
+
+            if (!NativeMethods.IsWindow(entry.Hwnd))
+            {
+                warning = $"[경고] 무효 핸들: {entry.Title} {entry.HwndHex}";
+                return false;
+            }
+
+            try
+            {
+                var element = AutomationElement.FromHandle(entry.Hwnd);
+                if (element is null)
+                {
+                    warning = $"[경고] UI Automation 요소 생성 실패: {entry.Title}";
+                    return false;
+                }
+
+                text = ExtractText(element);
+                text ??= string.Empty;
+                return true;
+            }
+            catch (ElementNotAvailableException)
+            {
+                warning = $"[경고] UI 요소가 닫혔습니다: {entry.Title}";
+                return false;
+            }
+            catch (InvalidOperationException ex)
+            {
+                warning = $"[경고] UI Automation 오류: {ex.Message}";
+                return false;
+            }
+            catch (Exception ex)
+            {
+                warning = $"[경고] UI Automation 예기치 못한 오류: {ex.Message}";
+                return false;
+            }
         }
 
-        private static void FocusParent(IntPtr parent)
+        private static string ExtractText(AutomationElement element)
         {
-            NativeMethods.SendMessage(parent, NativeConstants.WM_ACTIVATE, (IntPtr)NativeConstants.WA_ACTIVE, IntPtr.Zero);
-            NativeMethods.SetForegroundWindow(parent);
+            if (TryGetPatternText(element, out var directText))
+            {
+                return NormalizeText(directText);
+            }
+
+            var sb = new StringBuilder();
+            string? lastSegment = null;
+
+            AppendSegment(sb, TryExtractElementText(element), ref lastSegment);
+            CollectDescendantText(element, sb, ref lastSegment);
+
+            return sb.ToString();
         }
 
-        private static void SelectAllAndCopy(IntPtr hwnd)
+        private static void CollectDescendantText(AutomationElement root, StringBuilder sb, ref string? lastSegment)
         {
-            PressKeyCombo(hwnd, NativeConstants.VK_CONTROL, NativeConstants.VK_A, false);
-            Thread.Sleep(30);
-            PressKeyCombo(hwnd, NativeConstants.VK_CONTROL, NativeConstants.VK_C, false);
-        }
+            var queue = new Queue<AutomationElement>();
 
-        private static void DeselectList(IntPtr hwnd)
-        {
-            IntPtr point = NativeMethods.MakeLParam(30, 3);
-            NativeMethods.PostMessage(hwnd, NativeConstants.WM_LBUTTONDOWN, (IntPtr)1, point);
-            NativeMethods.PostMessage(hwnd, NativeConstants.WM_LBUTTONUP, IntPtr.Zero, point);
-        }
-
-        private static void PressKeyCombo(IntPtr hwnd, int modifierVk, int keyVk, bool sysKey)
-        {
-            if (!NativeMethods.IsWindow(hwnd))
+            try
+            {
+                var initial = root.FindAll(TreeScope.Children, Condition.TrueCondition);
+                for (int i = 0; i < initial.Count; i++)
+                {
+                    queue.Enqueue(initial[i]);
+                }
+            }
+            catch (ElementNotAvailableException)
+            {
                 return;
+            }
 
-            uint targetThread = NativeMethods.GetWindowThreadProcessId(hwnd, out _);
-            uint currentThread = NativeMethods.GetCurrentThreadId();
+            while (queue.Count > 0)
+            {
+                var current = queue.Dequeue();
 
-            NativeMethods.AttachThreadInput(currentThread, targetThread, true);
+                string? text = null;
+                try
+                {
+                    text = TryExtractElementText(current);
+                }
+                catch (ElementNotAvailableException)
+                {
+                    continue;
+                }
 
-            var oldState = new byte[256];
-            var newState = new byte[256];
-            NativeMethods.GetKeyboardState(oldState);
-            Array.Copy(oldState, newState, 256);
+                AppendSegment(sb, text, ref lastSegment);
 
-            newState[modifierVk] |= 0x80;
-            NativeMethods.SetKeyboardState(newState);
+                try
+                {
+                    var children = current.FindAll(TreeScope.Children, Condition.TrueCondition);
+                    for (int i = 0; i < children.Count; i++)
+                    {
+                        queue.Enqueue(children[i]);
+                    }
+                }
+                catch (ElementNotAvailableException)
+                {
+                }
+            }
+        }
 
-            int msgDown = sysKey ? NativeConstants.WM_SYSKEYDOWN : NativeConstants.WM_KEYDOWN;
-            int msgUp = sysKey ? NativeConstants.WM_SYSKEYUP : NativeConstants.WM_KEYUP;
+        private static bool TryGetPatternText(AutomationElement element, out string? text)
+        {
+            if (element.TryGetCurrentPattern(TextPattern.Pattern, out var textPatternObj) && textPatternObj is TextPattern textPattern)
+            {
+                text = textPattern.DocumentRange.GetText(-1);
+                if (!string.IsNullOrEmpty(text))
+                {
+                    return true;
+                }
+            }
 
-            IntPtr lparam = NativeMethods.MakeKeyLParam((uint)keyVk);
-            NativeMethods.PostMessage(hwnd, msgDown, (IntPtr)keyVk, lparam);
-            Thread.Sleep(10);
-            NativeMethods.PostMessage(hwnd, msgUp, (IntPtr)keyVk, (IntPtr)(lparam.ToInt64() | (1L << 30) | (1L << 31)));
+            if (element.TryGetCurrentPattern(ValuePattern.Pattern, out var valuePatternObj) && valuePatternObj is ValuePattern valuePattern)
+            {
+                text = valuePattern.Current.Value;
+                if (!string.IsNullOrEmpty(text))
+                {
+                    return true;
+                }
+            }
 
-            Array.Copy(oldState, newState, 256);
-            NativeMethods.SetKeyboardState(newState);
+            text = null;
+            return false;
+        }
 
-            NativeMethods.AttachThreadInput(currentThread, targetThread, false);
+        private static string? TryExtractElementText(AutomationElement element)
+        {
+            try
+            {
+                if (element.TryGetCurrentPattern(TextPattern.Pattern, out var textPatternObj) && textPatternObj is TextPattern textPattern)
+                {
+                    string text = textPattern.DocumentRange.GetText(-1);
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        return text;
+                    }
+                }
+
+                if (element.TryGetCurrentPattern(ValuePattern.Pattern, out var valuePatternObj) && valuePatternObj is ValuePattern valuePattern)
+                {
+                    string text = valuePattern.Current.Value;
+                    if (!string.IsNullOrEmpty(text))
+                    {
+                        return text;
+                    }
+                }
+
+                if (element.TryGetCurrentPattern(LegacyIAccessiblePattern.Pattern, out var legacyPatternObj) && legacyPatternObj is LegacyIAccessiblePattern legacy)
+                {
+                    string? value = legacy.Current.Value;
+                    if (!string.IsNullOrEmpty(value))
+                    {
+                        return value;
+                    }
+
+                    string? name = legacy.Current.Name;
+                    if (!string.IsNullOrEmpty(name))
+                    {
+                        return name;
+                    }
+                }
+
+                var controlType = element.Current.ControlType;
+                string nameProperty = element.Current.Name;
+
+                if (!string.IsNullOrEmpty(nameProperty))
+                {
+                    if (controlType == ControlType.Text ||
+                        controlType == ControlType.Document ||
+                        controlType == ControlType.ListItem ||
+                        controlType == ControlType.Edit)
+                    {
+                        return nameProperty;
+                    }
+                }
+            }
+            catch (ElementNotAvailableException)
+            {
+                return null;
+            }
+
+            return null;
+        }
+
+        private static void AppendSegment(StringBuilder sb, string? rawText, ref string? lastSegment)
+        {
+            if (string.IsNullOrWhiteSpace(rawText))
+            {
+                return;
+            }
+
+            string normalized = NormalizeText(rawText);
+
+            if (string.IsNullOrEmpty(normalized))
+            {
+                return;
+            }
+
+            if (string.Equals(normalized, lastSegment, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            if (sb.Length > 0)
+            {
+                sb.AppendLine();
+            }
+
+            sb.Append(normalized);
+            lastSegment = normalized;
+        }
+
+        private static string NormalizeText(string? text)
+        {
+            if (string.IsNullOrEmpty(text))
+            {
+                return string.Empty;
+            }
+
+            string normalized = text.Replace("\r\n", "\n").Replace('\r', '\n');
+            normalized = normalized.Trim('\n');
+            return normalized.Replace("\n", Environment.NewLine);
         }
     }
 }

--- a/WpfApp5/WpfApp5.csproj
+++ b/WpfApp5/WpfApp5.csproj
@@ -12,4 +12,9 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Reference Include="UIAutomationClient" />
+    <Reference Include="UIAutomationTypes" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- switch the capture pipeline from clipboard-based selection to UI Automation text extraction of EVA_VH_ListControl_Dblclk chat panes
- extend the chat window interactor to traverse automation elements and gather message text, updating the capture service/result to return the scraped content
- reference the UI Automation assemblies and adjust the main window wiring to consume the new capture flow

## Testing
- dotnet build WpfSol5-kakaotalkpcexporter.sln *(fails: `dotnet` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cb6a8fb9d0832eb93ee13c1a360d1a