### PR TITLE
Implement KakaoTalk chat send functionality

### DIFF
--- a/WpfApp5/Interop/NativeConstants.cs
+++ b/WpfApp5/Interop/NativeConstants.cs
@@ -4,15 +4,22 @@ namespace KakaoPcLogger.Interop
     {
         internal const int WM_ACTIVATE = 0x0006;
         internal const int WA_ACTIVE = 1;
+        internal const int WM_SETTEXT = 0x000C;
         internal const int WM_KEYDOWN = 0x0100;
         internal const int WM_KEYUP = 0x0101;
+        internal const int WM_CHAR = 0x0102;
         internal const int WM_SYSKEYDOWN = 0x0104;
         internal const int WM_SYSKEYUP = 0x0105;
         internal const int WM_LBUTTONDOWN = 0x0201;
         internal const int WM_LBUTTONUP = 0x0202;
 
+        internal const int VK_RETURN = 0x0D;
         internal const int VK_CONTROL = 0x11;
         internal const int VK_A = 0x41;
         internal const int VK_C = 0x43;
+
+        internal const int GWL_STYLE = -16;
+        internal const int ES_MULTILINE = 0x0004;
+        internal const int ES_READONLY = 0x0800;
     }
 }

--- a/WpfApp5/Interop/NativeMethods.cs
+++ b/WpfApp5/Interop/NativeMethods.cs
@@ -26,6 +26,9 @@ namespace KakaoPcLogger.Interop
         [DllImport("user32.dll")]
         internal static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
 
+        [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+        internal static extern IntPtr SendMessage(IntPtr hWnd, int Msg, IntPtr wParam, string? lParam);
+
         [DllImport("user32.dll")]
         internal static extern bool PostMessage(IntPtr hWnd, int Msg, IntPtr wParam, IntPtr lParam);
 
@@ -49,6 +52,9 @@ namespace KakaoPcLogger.Interop
 
         [DllImport("user32.dll")]
         internal static extern bool SetForegroundWindow(IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        internal static extern int GetWindowLong(IntPtr hWnd, int nIndex);
 
         internal static IntPtr MakeLParam(int low, int high)
             => (IntPtr)((high << 16) | (low & 0xFFFF));

--- a/WpfApp5/MainWindow.xaml.cs
+++ b/WpfApp5/MainWindow.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.IO;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Threading;
 using KakaoPcLogger.Models;
@@ -19,21 +20,26 @@ namespace KakaoPcLogger
         private readonly DispatcherTimer _timer = new();
         private readonly ChatLogManager _chatLogManager = new();
         private readonly ChatWindowScanner _scanner = new(TargetProcessName, KakaoChatListClass);
+        private readonly ChatWindowInteractor _windowInteractor = new();
         private readonly ChatCaptureService _captureService;
+        private readonly ChatSendService _sendService;
         private readonly string _dbPath;
 
         private long _captureCount;
         private int _rrIndex;
         private string? _currentViewKey;
+        private ChatEntry? _sendTarget;
 
         public MainWindow()
         {
             InitializeComponent();
 
             _dbPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "data", "kakao_chat_v2.db");
-            _captureService = new ChatCaptureService(new ChatWindowInteractor(), new ClipboardService(), _dbPath);
+            _captureService = new ChatCaptureService(_windowInteractor, new ClipboardService(), _dbPath);
+            _sendService = new ChatSendService(_windowInteractor);
 
             LvChats.ItemsSource = _chats;
+            LvChats.SelectionChanged += OnChatSelectionChanged;
 
             BtnScan.Click += (_, __) => ScanChats();
             BtnStart.Click += (_, __) => StartCapture();
@@ -59,6 +65,14 @@ namespace KakaoPcLogger
             ChkSelectAll.Checked += (_, __) => SetAllSelection(true);
             ChkSelectAll.Unchecked += (_, __) => SetAllSelection(false);
 
+            BtnSend.Click += (_, __) => SendComposer();
+            BtnClearComposer.Click += (_, __) => ClearComposer();
+            TxtComposer.TextChanged += OnComposerTextChanged;
+            TxtComposer.PreviewKeyDown += OnComposerPreviewKeyDown;
+
+            UpdateSendTargetLabel();
+            UpdateComposerCount();
+
             _timer.Tick += OnTick;
             _timer.Interval = TimeSpan.FromMilliseconds(1500);
 
@@ -71,6 +85,8 @@ namespace KakaoPcLogger
         {
             if (LvChats.SelectedItem is ChatEntry entry)
             {
+                SetSendTarget(entry);
+
                 string key = _chatLogManager.GetKey(entry);
                 _currentViewKey = key;
 
@@ -85,6 +101,14 @@ namespace KakaoPcLogger
             }
         }
 
+        private void OnChatSelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (LvChats.SelectedItem is ChatEntry entry)
+            {
+                SetSendTarget(entry);
+            }
+        }
+
         private void ScanChats()
         {
             try
@@ -92,10 +116,27 @@ namespace KakaoPcLogger
                 bool autoInclude = ChkAutoInclude.IsChecked == true;
                 var found = _scanner.Scan(autoInclude);
 
+                IntPtr previousTarget = _sendTarget?.Hwnd ?? IntPtr.Zero;
+
                 _chats.Clear();
+                ChatEntry? matchedTarget = null;
                 foreach (var chat in found)
                 {
                     _chats.Add(chat);
+                    if (previousTarget != IntPtr.Zero && chat.Hwnd == previousTarget)
+                    {
+                        matchedTarget = chat;
+                    }
+                }
+
+                SetSendTarget(matchedTarget);
+                if (matchedTarget != null)
+                {
+                    LvChats.SelectedItem = matchedTarget;
+                }
+                else
+                {
+                    LvChats.SelectedItem = null;
                 }
 
                 TxtChatCount.Text = _chats.Count.ToString();
@@ -299,6 +340,160 @@ namespace KakaoPcLogger
             {
                 TxtLog.ScrollToEnd();
             }
+        }
+
+        private void SetSendTarget(ChatEntry? entry)
+        {
+            if (entry is null)
+            {
+                _sendTarget = null;
+                UpdateSendTargetLabel();
+                return;
+            }
+
+            foreach (var chat in _chats)
+            {
+                if (chat.Hwnd == entry.Hwnd)
+                {
+                    _sendTarget = chat;
+                    UpdateSendTargetLabel();
+                    return;
+                }
+            }
+
+            _sendTarget = entry;
+            UpdateSendTargetLabel();
+        }
+
+        private void UpdateSendTargetLabel()
+        {
+            if (_sendTarget is ChatEntry target)
+            {
+                TxtSendTarget.Text = $"{target.Title} ({target.HwndHex})";
+            }
+            else
+            {
+                TxtSendTarget.Text = "(미선택)";
+            }
+        }
+
+        private ChatEntry? ResolveSendTarget()
+        {
+            if (_sendTarget is not null)
+            {
+                foreach (var chat in _chats)
+                {
+                    if (chat.Hwnd == _sendTarget.Hwnd)
+                    {
+                        if (!ReferenceEquals(chat, _sendTarget))
+                        {
+                            _sendTarget = chat;
+                            UpdateSendTargetLabel();
+                        }
+
+                        return _sendTarget;
+                    }
+                }
+
+                _sendTarget = null;
+                UpdateSendTargetLabel();
+            }
+
+            if (LvChats.SelectedItem is ChatEntry selected)
+            {
+                SetSendTarget(selected);
+                return _sendTarget;
+            }
+
+            return null;
+        }
+
+        private bool SendComposer()
+        {
+            string text = TxtComposer.Text;
+            if (string.IsNullOrWhiteSpace(text))
+            {
+                AppendLog("[송신] 메시지가 비어 있어 전송하지 않았습니다.");
+                return false;
+            }
+
+            var target = ResolveSendTarget();
+            if (target is null)
+            {
+                AppendLog("[송신] 대상 채팅방이 선택되지 않았습니다.");
+                return false;
+            }
+
+            try
+            {
+                if (!_sendService.TrySendMessage(target, text, out var error))
+                {
+                    AppendLog(error ?? "[송신] 전송 실패");
+                    return false;
+                }
+            }
+            catch (Exception ex)
+            {
+                AppendLog($"[송신 오류] {ex.GetType().Name}: {ex.Message}");
+                return false;
+            }
+
+            AppendLog($"[송신] {target.Title} ({target.HwndHex}) ← {text.Length}자 메시지 전송");
+            TxtComposer.Clear();
+
+            if (ChkKeepFocusAfterSend.IsChecked == true)
+            {
+                Dispatcher.BeginInvoke(new Action(() => TxtComposer.Focus()), DispatcherPriority.ApplicationIdle);
+            }
+
+            return true;
+        }
+
+        private void ClearComposer()
+        {
+            TxtComposer.Clear();
+            TxtComposer.Focus();
+        }
+
+        private void OnComposerTextChanged(object sender, TextChangedEventArgs e)
+        {
+            UpdateComposerCount();
+        }
+
+        private void OnComposerPreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key != Key.Enter && e.Key != Key.Return)
+            {
+                return;
+            }
+
+            ModifierKeys modifiers = Keyboard.Modifiers;
+            bool hasCtrl = (modifiers & ModifierKeys.Control) == ModifierKeys.Control;
+            bool hasShift = (modifiers & ModifierKeys.Shift) == ModifierKeys.Shift;
+            bool hasAlt = (modifiers & ModifierKeys.Alt) == ModifierKeys.Alt;
+            bool enterToSend = ChkEnterToSend.IsChecked == true;
+
+            if (enterToSend)
+            {
+                if (!hasCtrl && !hasShift && !hasAlt)
+                {
+                    e.Handled = true;
+                    SendComposer();
+                }
+            }
+            else
+            {
+                if (hasCtrl && !hasShift && !hasAlt)
+                {
+                    e.Handled = true;
+                    SendComposer();
+                }
+            }
+        }
+
+        private void UpdateComposerCount()
+        {
+            TxtComposerCount.Text = TxtComposer.Text.Length.ToString();
         }
     }
 }

--- a/WpfApp5/Services/ChatSendService.cs
+++ b/WpfApp5/Services/ChatSendService.cs
@@ -1,0 +1,19 @@
+using KakaoPcLogger.Models;
+
+namespace KakaoPcLogger.Services
+{
+    public sealed class ChatSendService
+    {
+        private readonly ChatWindowInteractor _windowInteractor;
+        private readonly string _inputClassName;
+
+        public ChatSendService(ChatWindowInteractor windowInteractor, string inputClassName = "RICHEDIT50W")
+        {
+            _windowInteractor = windowInteractor;
+            _inputClassName = inputClassName;
+        }
+
+        public bool TrySendMessage(ChatEntry entry, string message, out string? error)
+            => _windowInteractor.TrySendMessage(entry, message, _inputClassName, out error);
+    }
+}


### PR DESCRIPTION
## Summary
- add ChatSendService and extend ChatWindowInteractor to locate the KakaoTalk rich edit composer, set its text, and post an Enter keypress
- update MainWindow to manage the send target, handle composer events, and trigger message transmission through the new service
- expose additional Win32 interop constants and helpers required to manipulate the rich edit control

## Testing
- `dotnet build WpfSol5-kakaotalkpcexporter.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ccd2fd7b00832e9114b23272d63de8