### PR TITLE
Implement Flash capture window recycle

### DIFF
--- a/WpfApp5/Interop/NativeConstants.cs
+++ b/WpfApp5/Interop/NativeConstants.cs
@@ -12,11 +12,13 @@
         internal const int WM_SYSKEYUP = 0x0105;
         internal const int WM_LBUTTONDOWN = 0x0201;
         internal const int WM_LBUTTONUP = 0x0202;
+        internal const int WM_LBUTTONDBLCLK = 0x0203;
 
         internal const int VK_RETURN = 0x0D;
         internal const int VK_CONTROL = 0x11;
         internal const int VK_A = 0x41;
         internal const int VK_C = 0x43;
+        internal const int VK_ESCAPE = 0x1B;
         internal const int VK_BACK = 0x08;   // Backspace key
 
         internal const int GWL_STYLE = -16;

--- a/WpfApp5/Services/ChatCaptureResult.cs
+++ b/WpfApp5/Services/ChatCaptureResult.cs
@@ -1,3 +1,5 @@
+using KakaoPcLogger.Models;
+
 namespace KakaoPcLogger.Services
 {
     public sealed class ChatCaptureResult
@@ -7,5 +9,6 @@ namespace KakaoPcLogger.Services
         public string? Warning { get; init; }
         public string? DbMessage { get; init; }
         public string? DbError { get; init; }
+        public ChatEntry? ReplacementEntry { get; init; }
     }
 }

--- a/WpfApp5/Services/ChatLogManager.cs
+++ b/WpfApp5/Services/ChatLogManager.cs
@@ -58,5 +58,17 @@ namespace KakaoPcLogger.Services
             text = string.Empty;
             return false;
         }
+
+        public void ReplaceKey(string oldKey, ChatEntry updatedEntry)
+        {
+            if (string.IsNullOrEmpty(oldKey))
+                return;
+
+            if (!_logs.TryGetValue(oldKey, out var sb))
+                return;
+
+            _logs.Remove(oldKey);
+            _logs[GetKey(updatedEntry)] = sb;
+        }
     }
 }


### PR DESCRIPTION
## Summary
- close the captured chat window during FLASH capture, reopen it via the KakaoTalk main window, and rescan for the new handles
- propagate the refreshed handles back to the UI and chat log manager so in-memory state follows the reopened window
- add the interop helpers and constants required to send ESC and double-click events, plus carry replacement window data in capture results

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e8b5df04832ebd422465c394f4cc