### PR TITLE
Add message order column to messages table

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ WPF GUI 앱으로, Windows PC 카카오톡 채팅방의 메시지를 주기적�
 - `data/kakao_chat.db`  
   - `chats` : 채팅방 메타정보
   - `messages` : 메시지(`sender`, `ts_local`, `content`, `hash`)
-- `hash = SHA256(ts_local + "\n" + content)`  
+- `hash = SHA256(chat_id + "\n" + sender + "\n" + ts_local + "\n" + content)`
   → `UNIQUE(chat_id, hash)` 로 중복 저장 방지
 
 ---

--- a/WpfApp5/Models/ParsedMessage.cs
+++ b/WpfApp5/Models/ParsedMessage.cs
@@ -7,5 +7,6 @@ namespace KakaoPcLogger.Models
         public string Sender { get; init; } = string.Empty;
         public DateTime LocalTs { get; init; }
         public string Content { get; init; } = string.Empty;
+        public int Order { get; init; }
     }
 }

--- a/WpfApp5/Parsing/ChatParserEn.cs
+++ b/WpfApp5/Parsing/ChatParserEn.cs
@@ -46,7 +46,8 @@ namespace KakaoPcLogger.Parsing
                     {
                         Sender = currentSender,
                         LocalTs = currentTs.Value,
-                        Content = content
+                        Content = content,
+                        Order = results.Count
                     });
                 }
 

--- a/WpfApp5/Parsing/ChatParserKo.cs
+++ b/WpfApp5/Parsing/ChatParserKo.cs
@@ -46,7 +46,8 @@ namespace KakaoPcLogger.Parsing
                     {
                         Sender = currentSender,
                         LocalTs = currentTs.Value,
-                        Content = content
+                        Content = content,
+                        Order = results.Count
                     });
                 }
                 currentSender = null;


### PR DESCRIPTION
## Summary
- add an `order` column with a default of zero to the `messages` table and backfill it for existing databases
- capture sequential order information when parsing chats and persist it alongside message records
- extend `ParsedMessage` to carry the extracted order value for database inserts

## Testing
- dotnet build *(fails: dotnet CLI is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9d8ca1bb4832eb0c69bda36e5796c