### PR TITLE
Document FLASH webhook notifications

### DIFF
--- a/WpfApp5/Models/SavedMessage.cs
+++ b/WpfApp5/Models/SavedMessage.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace KakaoPcLogger.Models
+{
+    public sealed class SavedMessage
+    {
+        public string Sender { get; init; } = string.Empty;
+        public DateTime LocalTs { get; init; }
+        public string Content { get; init; } = string.Empty;
+        public int MsgOrder { get; init; }
+    }
+}

--- a/WpfApp5/Services/ChatCaptureResult.cs
+++ b/WpfApp5/Services/ChatCaptureResult.cs
@@ -1,3 +1,7 @@
+using System;
+using System.Collections.Generic;
+using KakaoPcLogger.Models;
+
 namespace KakaoPcLogger.Services
 {
     public sealed class ChatCaptureResult
@@ -7,5 +11,6 @@ namespace KakaoPcLogger.Services
         public string? Warning { get; init; }
         public string? DbMessage { get; init; }
         public string? DbError { get; init; }
+        public IReadOnlyList<SavedMessage> NewMessages { get; init; } = Array.Empty<SavedMessage>();
     }
 }

--- a/WpfApp5/Services/ChatCaptureService.cs
+++ b/WpfApp5/Services/ChatCaptureService.cs
@@ -58,6 +58,7 @@ namespace KakaoPcLogger.Services
 
             string? dbMessage = null;
             string? dbError = null;
+            IReadOnlyList<SavedMessage> newlySaved = Array.Empty<SavedMessage>();
 
             try
             {
@@ -67,8 +68,16 @@ namespace KakaoPcLogger.Services
 
                 if (parsed.Count > 0)
                 {
-                    ChatDatabase.SaveMessages(_dbPath, chatId, parsed);
-                    dbMessage = $"[DB] 저장됨: {parsed.Count}건 ({entry.Title})\n";
+                    newlySaved = ChatDatabase.SaveMessages(_dbPath, chatId, parsed);
+                    int insertedCount = newlySaved.Count;
+                    if (insertedCount > 0)
+                    {
+                        dbMessage = $"[DB] 저장됨: {insertedCount}건 ({entry.Title})\\n";
+                    }
+                    else
+                    {
+                        dbMessage = $"[DB] 신규 저장 없음 ({entry.Title})\\n";
+                    }
                 }
                 else
                 {
@@ -85,7 +94,8 @@ namespace KakaoPcLogger.Services
                 Success = true,
                 ClipboardText = clipboardText,
                 DbMessage = dbMessage,
-                DbError = dbError
+                DbError = dbError,
+                NewMessages = newlySaved
             };
         }
 

--- a/WpfApp5/Services/WebhookNotificationService.cs
+++ b/WpfApp5/Services/WebhookNotificationService.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using KakaoPcLogger.Models;
+
+namespace KakaoPcLogger.Services
+{
+    public sealed class WebhookNotificationService : IDisposable
+    {
+        private readonly Uri? _endpoint;
+        private readonly HttpClient _httpClient;
+        private readonly JsonSerializerOptions _jsonOptions;
+        private readonly Action<string>? _log;
+        private bool _missingEndpointLogged;
+        private readonly object _logLock = new();
+
+        public WebhookNotificationService(Uri? endpoint, Action<string>? log)
+        {
+            _endpoint = endpoint;
+            _log = log;
+            _httpClient = new HttpClient();
+            _jsonOptions = new JsonSerializerOptions
+            {
+                Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            };
+        }
+
+        public async Task NotifyNewMessagesAsync(string chatRoom, IReadOnlyList<SavedMessage> messages, CancellationToken cancellationToken = default)
+        {
+            if (messages == null || messages.Count == 0)
+            {
+                return;
+            }
+
+            if (_endpoint is null)
+            {
+                LogMissingEndpointOnce();
+                return;
+            }
+
+            foreach (var message in messages)
+            {
+                try
+                {
+                    var payload = new
+                    {
+                        chatRoom,
+                        sender = message.Sender,
+                        timestamp = message.LocalTs.ToString("yyyy-MM-dd HH:mm:ss"),
+                        order = message.MsgOrder,
+                        content = message.Content
+                    };
+
+                    using var content = new StringContent(JsonSerializer.Serialize(payload, _jsonOptions), Encoding.UTF8, "application/json");
+                    using var response = await _httpClient.PostAsync(_endpoint, content, cancellationToken).ConfigureAwait(false);
+
+                    if (response.IsSuccessStatusCode)
+                    {
+                        _log?.Invoke($"[Webhook] 전송 성공: {chatRoom} #{message.MsgOrder}");
+                    }
+                    else
+                    {
+                        string body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+                        _log?.Invoke($"[Webhook] 실패({(int)response.StatusCode}): {body}");
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    throw;
+                }
+                catch (Exception ex)
+                {
+                    _log?.Invoke($"[Webhook] 예외: {ex.Message}");
+                }
+            }
+        }
+
+        private void LogMissingEndpointOnce()
+        {
+            lock (_logLock)
+            {
+                if (_missingEndpointLogged)
+                {
+                    return;
+                }
+
+                _missingEndpointLogged = true;
+                _log?.Invoke("[Webhook] 엔드포인트가 설정되지 않아 전송이 비활성화되었습니다.");
+            }
+        }
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- track which parsed messages are newly saved to the SQLite database
- expose saved messages in capture results and add a webhook notification service
- resolve a webhook endpoint from configuration and send FLASH-triggered inserts to the remote API
- document the outgoing webhook payload and configuration in REST_API.md

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68da49e06360832ea5518caf56db21ad