### PR TITLE
Externalize REST API and database configuration

### DIFF
--- a/WpfApp5/Configuration/AppConfiguration.cs
+++ b/WpfApp5/Configuration/AppConfiguration.cs
@@ -1,0 +1,75 @@
+using System;
+using System.IO;
+using System.Text.Json;
+
+namespace WpfApp5.Configuration
+{
+    public sealed class AppConfiguration
+    {
+        public DatabaseConfiguration Database { get; init; } = new();
+        public RestApiConfiguration RestApi { get; init; } = new();
+
+        public static AppConfiguration Load(string baseDirectory)
+        {
+            if (baseDirectory is null)
+            {
+                throw new ArgumentNullException(nameof(baseDirectory));
+            }
+
+            var configPath = Path.Combine(baseDirectory, "appsettings.json");
+
+            AppConfiguration config;
+
+            if (!File.Exists(configPath))
+            {
+                config = new AppConfiguration();
+            }
+            else
+            {
+                using var stream = File.OpenRead(configPath);
+                config = JsonSerializer.Deserialize<AppConfiguration>(stream, new JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true,
+                    ReadCommentHandling = JsonCommentHandling.Skip,
+                    AllowTrailingCommas = true
+                }) ?? new AppConfiguration();
+            }
+
+            config.Database.Path = ResolveDatabasePath(baseDirectory, config.Database.Path);
+            config.RestApi.Prefix = ResolveRestApiPrefix(config.RestApi.Prefix);
+
+            return config;
+        }
+
+        private static string ResolveDatabasePath(string baseDirectory, string? configuredPath)
+        {
+            var path = string.IsNullOrWhiteSpace(configuredPath)
+                ? Path.Combine("data", "kakao_chat_v2.db")
+                : configuredPath;
+
+            if (!Path.IsPathRooted(path))
+            {
+                path = Path.GetFullPath(Path.Combine(baseDirectory, path));
+            }
+
+            return path;
+        }
+
+        private static string ResolveRestApiPrefix(string? configuredPrefix)
+        {
+            return string.IsNullOrWhiteSpace(configuredPrefix)
+                ? "http://localhost:5010/"
+                : configuredPrefix;
+        }
+    }
+
+    public sealed class DatabaseConfiguration
+    {
+        public string? Path { get; set; }
+    }
+
+    public sealed class RestApiConfiguration
+    {
+        public string? Prefix { get; set; }
+    }
+}

--- a/WpfApp5/WpfApp5.csproj
+++ b/WpfApp5/WpfApp5.csproj
@@ -12,4 +12,10 @@
     <PackageReference Include="Microsoft.Data.Sqlite" Version="9.0.9" />
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/WpfApp5/appsettings.json
+++ b/WpfApp5/appsettings.json
@@ -1,0 +1,8 @@
+{
+  "Database": {
+    "Path": "data/kakao_chat_v2.db"
+  },
+  "RestApi": {
+    "Prefix": "http://localhost:5010/"
+  }
+}


### PR DESCRIPTION
## Summary
- add an appsettings.json file to store the REST API prefix and SQLite database path
- load configuration at startup so services use the configured values instead of hard-coded defaults
- ensure the configuration file is copied to the output directory for deployment

## Testing
- dotnet build *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db218f80d8832e9c6af1c0116abb5a