### PR TITLE
Split REST API listener host and port configuration

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -6,7 +6,7 @@ This document describes the lightweight REST interface exposed by **KakaoTalk PC
 
 - The API service starts automatically when the main WPF application launches. A log entry like `[REST] 서비스가 시작되었습니다.` is appended to the in-app log when the listener is ready.
 - The service is automatically disposed when the main window is closed. No additional action is required from users.
-- By default the listener binds to `http://localhost:5010/`. The prefix can be adjusted in code when constructing `RestApiService` if needed.
+- By default the listener binds to `http://localhost:5010/`. You can change the host or port without recompiling by editing `appsettings.json` (`RestApi:Host`, `RestApi:Port`). Set `RestApi:UseHttps` to `true` once the appropriate HTTPS certificate binding has been configured on the machine.
 - Flash 캡처가 새로운 메시지를 저장할 때 애플리케이션은 기본적으로 `http://localhost:8080/` 으로 Webhook 알림을 발송한다. 다른 서버로 전달하고 싶다면 `appsettings.json`의 `Webhook:MessageUpdateUrl` 값을 수정하면 된다.
 
 > **Note:** The service uses the built-in `HttpListener` class. Running behind a firewall or on a restricted network may require granting URL ACL permissions for the chosen prefix.
@@ -83,7 +83,7 @@ Invoke-RestMethod "http://localhost:5010/messages/$encodedTitle"
 
 ## Troubleshooting
 
-- **Port already in use:** Ensure nothing else is bound to port `5010`, or change the prefix in `RestApiService` construction.
+- **Port already in use:** Ensure nothing else is bound to port `5010`, or update `RestApi:Port` in `appsettings.json`.
 - **Access denied when starting the listener:** Run the application with administrator privileges or register the URL ACL via `netsh http add urlacl url=http://+:5010/ user=DOMAIN\\User`.
 - **Empty responses:** Confirm the target chat has been captured and stored in the SQLite database located at `data/kakao_chat_v2.db`.
 

--- a/WpfApp5/appsettings.json
+++ b/WpfApp5/appsettings.json
@@ -3,7 +3,9 @@
     "Path": "data/kakao_chat_v2.db"
   },
   "RestApi": {
-    "Prefix": "http://localhost:5010/"
+    "Host": "localhost",
+    "Port": 5010,
+    "UseHttps": false
   },
   "Webhook": {
     "MessageUpdateUrl": "http://localhost:8080/"


### PR DESCRIPTION
## Summary
- replace the single RestApi prefix setting with discrete host, port, and HTTPS toggle fields
- normalize the configuration into a listener prefix dynamically so the runtime can switch schemes later
- refresh the sample configuration file and documentation to explain the new options

## Testing
- Not run (dotnet CLI is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68db2aed6324832ea73663bf7c0d576c