### PR TITLE
Allow REST API listener to accept any host

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -6,7 +6,7 @@ This document describes the lightweight REST interface exposed by **KakaoTalk PC
 
 - The API service starts automatically when the main WPF application launches. A log entry like `[REST] 서비스가 시작되었습니다.` is appended to the in-app log when the listener is ready.
 - The service is automatically disposed when the main window is closed. No additional action is required from users.
-- By default the listener binds to `http://localhost:5010/`. You can change the host or port without recompiling by editing `appsettings.json` (`RestApi:Host`, `RestApi:Port`). Set `RestApi:UseHttps` to `true` once the appropriate HTTPS certificate binding has been configured on the machine.
+- By default the listener binds to `http://localhost:5010/`. You can change the host or port without recompiling by editing `appsettings.json` (`RestApi:Host`, `RestApi:Port`). To listen on every hostname, set `RestApi:AllowAnyHost` to `true`, which internally uses the strong wildcard prefix `http://+:<port>/`. Set `RestApi:UseHttps` to `true` once the appropriate HTTPS certificate binding has been configured on the machine.
 - Flash 캡처가 새로운 메시지를 저장할 때 애플리케이션은 기본적으로 `http://localhost:8080/` 으로 Webhook 알림을 발송한다. 다른 서버로 전달하고 싶다면 `appsettings.json`의 `Webhook:MessageUpdateUrl` 값을 수정하면 된다.
 
 > **Note:** The service uses the built-in `HttpListener` class. Running behind a firewall or on a restricted network may require granting URL ACL permissions for the chosen prefix.

--- a/WpfApp5/Configuration/AppConfiguration.cs
+++ b/WpfApp5/Configuration/AppConfiguration.cs
@@ -85,16 +85,28 @@ namespace WpfApp5.Configuration
     {
         private const string DefaultHost = "localhost";
         private const int DefaultPort = 5010;
+        private const string AnyHostWildcard = "+";
 
         public string? Host { get; set; } = DefaultHost;
         public int? Port { get; set; } = DefaultPort;
         public bool UseHttps { get; set; }
+        public bool AllowAnyHost { get; set; }
 
         [JsonIgnore]
         public string? Prefix => BuildPrefix();
 
         public void Normalize()
         {
+            if (AllowAnyHost)
+            {
+                if (Port is null || Port <= 0 || Port > 65535)
+                {
+                    Port = DefaultPort;
+                }
+
+                return;
+            }
+
             if (Host is null)
             {
                 Host = DefaultHost;
@@ -115,6 +127,19 @@ namespace WpfApp5.Configuration
 
         public string? BuildPrefix()
         {
+            var effectivePort = Port ?? DefaultPort;
+            if (effectivePort <= 0 || effectivePort > 65535)
+            {
+                return null;
+            }
+
+            var scheme = UseHttps ? "https" : "http";
+
+            if (AllowAnyHost)
+            {
+                return $"{scheme}://{AnyHostWildcard}:{effectivePort}/";
+            }
+
             if (string.IsNullOrWhiteSpace(Host))
             {
                 return null;
@@ -126,13 +151,6 @@ namespace WpfApp5.Configuration
                 return null;
             }
 
-            var effectivePort = Port ?? DefaultPort;
-            if (effectivePort <= 0 || effectivePort > 65535)
-            {
-                return null;
-            }
-
-            var scheme = UseHttps ? "https" : "http";
             return $"{scheme}://{effectiveHost}:{effectivePort}/";
         }
     }

--- a/WpfApp5/appsettings.json
+++ b/WpfApp5/appsettings.json
@@ -3,6 +3,7 @@
     "Path": "data/kakao_chat_v2.db"
   },
   "RestApi": {
+    "AllowAnyHost": false,
     "Host": "localhost",
     "Port": 5010,
     "UseHttps": false


### PR DESCRIPTION
## Summary
- add an `AllowAnyHost` toggle to the REST API configuration so the listener can bind to all hostnames
- update the default `appsettings.json` and REST API documentation to describe the new option

## Testing
- dotnet build WpfSol5-kakaotalkpcexporter.sln *(fails: `dotnet` CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db2d37ea24832eb2564be8b8d42854