### PR TITLE
Update webhook payload to include exporter host

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -118,13 +118,14 @@ To add more endpoints, follow the existing pattern inside `RestApiService.Proces
 
 ## Webhook notifications
 
-FLASH 방식 캡처로 DB에 새 메시지가 저장되면 각 메시지에 대해 `Webhook:RemoteHost` + `Webhook:Prefix` + `Webhook:MessageUpdateUrl`로 POST 요청이 전송된다. 기본값은 `http://localhost:8080/webhook/message-update`이며 다음과 같은 JSON 페이로드를 사용한다.
+FLASH 방식 캡처로 DB에 새 메시지가 저장되면 각 메시지에 대해 `Webhook:RemoteHost` + `Webhook:Prefix` + `Webhook:MessageUpdateUrl`로 POST 요청이 전송된다. 기본값은 `http://localhost:8080/api/webhook/message-update`이며 다음과 같은 JSON 페이로드를 사용한다.
 
 ```
 POST /api/webhook/message-update
 Content-Type: application/json; charset=utf-8
 
 {
+  "host": "mytesthost123",
   "chatRoom": "박주영",
   "sender": "박주영",
   "timestamp": "2025-09-29 10:30:00",
@@ -133,4 +134,4 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-타임스탬프는 `yyyy-MM-dd HH:mm:ss` 형식으로 직렬화되며, `order`는 `msg_order` 값을 그대로 전달한다. 다른 엔드포인트로 전달하려면 `appsettings.json`의 `Webhook:RemoteHost`, `Webhook:Prefix`, `Webhook:MessageUpdateUrl` 값을 원하는 값으로 조합해 수정하면 된다.
+타임스탬프는 `yyyy-MM-dd HH:mm:ss` 형식으로 직렬화되며, `order`는 `msg_order` 값을 그대로 전달한다. `host` 값은 `appsettings.json`의 `ExporterHostname` 설정을 사용하며, 기본값은 `mytesthost123`이다. 다른 엔드포인트로 전달하려면 `appsettings.json`의 `Webhook:RemoteHost`, `Webhook:Prefix`, `Webhook:MessageUpdateUrl` 값을 원하는 값으로 조합해 수정하면 된다.

--- a/WpfApp5/Configuration/AppConfiguration.cs
+++ b/WpfApp5/Configuration/AppConfiguration.cs
@@ -8,11 +8,26 @@ namespace WpfApp5.Configuration
 {
     public sealed class AppConfiguration
     {
+        private const string DefaultExporterHostname = "mytesthost123";
+
         public DatabaseConfiguration Database { get; init; }
         public RestApiConfiguration RestApi { get; init; }
         public WebhookConfiguration Webhook { get; init; }
+        public string ExporterHostname { get; set; }
 
-        // init Àü¿ë ¼Ó¼ºÀº »ı¼ºÀÚ¿¡¼­ ¼³Á¤ °¡´É
+            ExporterHostname = DefaultExporterHostname;
+            config.ExporterHostname = NormalizeExporterHostname(config.ExporterHostname);
+        private static string NormalizeExporterHostname(string? configured)
+        {
+            if (string.IsNullOrWhiteSpace(configured))
+            {
+                return DefaultExporterHostname;
+            }
+
+            return configured.Trim();
+        }
+
+        // init ì „ìš© ì†ì„±ì€ ìƒì„±ìì—ì„œ ì„¤ì • ê°€ëŠ¥
         public AppConfiguration()
         {
             Database = new DatabaseConfiguration();
@@ -275,8 +290,8 @@ namespace WpfApp5.Configuration
     public sealed class WebhookConfiguration
     {
         private const string DefaultRemoteHost = "http://localhost:8080";
-        private const string DefaultMessageUpdatePath = "/webhook/message-update";
-        private const string DefaultHealthCheckPath = "/webhook/health";
+        private const string DefaultMessageUpdatePath = "/api/webhook/message-update";
+        private const string DefaultHealthCheckPath = "/api/webhook/health";
 
         public string? RemoteHost { get; set; }
         public string? Prefix { get; set; }

--- a/WpfApp5/MainWindow.xaml.cs
+++ b/WpfApp5/MainWindow.xaml.cs
@@ -97,7 +97,7 @@ namespace KakaoPcLogger
             {
                 try
                 {
-                    _webhookService = new WebhookNotificationService(webhookEndpoint);
+                    _webhookService = new WebhookNotificationService(webhookEndpoint, _configuration.ExporterHostname);
                     _webhookService.Log += AppendLog;
                 }
                 catch (Exception ex)

--- a/WpfApp5/Services/WebhookNotificationService.cs
+++ b/WpfApp5/Services/WebhookNotificationService.cs
@@ -11,10 +11,13 @@ namespace KakaoPcLogger.Services
     public sealed class WebhookNotificationService : IDisposable
     {
         private readonly HttpClient _httpClient;
+        private const string DefaultExporterHostname = "mytesthost123";
+
         private readonly Uri _endpoint;
+        private readonly string _exporterHostname;
         private readonly JsonSerializerOptions _jsonOptions;
 
-        public WebhookNotificationService(string endpoint)
+        public WebhookNotificationService(string endpoint, string exporterHostname)
         {
             if (string.IsNullOrWhiteSpace(endpoint))
             {
@@ -28,6 +31,9 @@ namespace KakaoPcLogger.Services
 
             _endpoint = uri;
             _httpClient = new HttpClient();
+            _exporterHostname = string.IsNullOrWhiteSpace(exporterHostname)
+                ? DefaultExporterHostname
+                : exporterHostname.Trim();
             _jsonOptions = new JsonSerializerOptions
             {
                 PropertyNamingPolicy = JsonNamingPolicy.CamelCase
@@ -52,6 +58,7 @@ namespace KakaoPcLogger.Services
             {
                 var payload = new
                 {
+                    host = _exporterHostname,
                     chatRoom,
                     sender = message.Sender,
                     timestamp = message.LocalTs.ToString("yyyy-MM-dd HH:mm:ss"),

--- a/WpfApp5/appsettings.json
+++ b/WpfApp5/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "ExporterHostname": "mytesthost123",
   "Database": {
     "Path": "data/kakao_chat_v2.db"
   },
@@ -14,8 +15,7 @@
   },
   "Webhook": {
     "RemoteHost": "http://192.168.0.20:8080",
-    "Prefix": "/api",
-    "MessageUpdateUrl": "/webhook/message-update",
-    "HealthCheck": "/webhook/health"
+    "MessageUpdateUrl": "/api/webhook/message-update",
+    "HealthCheck": "/api/webhook/health"
   }
 }


### PR DESCRIPTION
## Summary
- add support for configuring an ExporterHostname in appsettings and include it in webhook payloads
- adjust webhook endpoint defaults and sample settings to target /api/webhook paths
- refresh REST API documentation to describe the new payload format

## Testing
- `dotnet build WpfSol5-kakaotalkpcexporter.sln` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dc728b8b0c832e8f41a5d4039046ed