### PR TITLE
Add exporter hostname to webhook payload

### DIFF
--- a/REST_API.md
+++ b/REST_API.md
@@ -125,6 +125,7 @@ POST /api/webhook/message-update
 Content-Type: application/json; charset=utf-8
 
 {
+  "host": "mytesthost123",
   "chatRoom": "박주영",
   "sender": "박주영",
   "timestamp": "2025-09-29 10:30:00",
@@ -133,4 +134,4 @@ Content-Type: application/json; charset=utf-8
 }
 ```
 
-타임스탬프는 `yyyy-MM-dd HH:mm:ss` 형식으로 직렬화되며, `order`는 `msg_order` 값을 그대로 전달한다. 다른 엔드포인트로 전달하려면 `appsettings.json`의 `Webhook:RemoteHost`, `Webhook:Prefix`, `Webhook:MessageUpdateUrl` 값을 원하는 값으로 조합해 수정하면 된다.
+`host` 필드는 `appsettings.json`의 `ExporterHostname` 값을 사용하며 기본값은 `mytesthost123`이다. 타임스탬프는 `yyyy-MM-dd HH:mm:ss` 형식으로 직렬화되며, `order`는 `msg_order` 값을 그대로 전달한다. 다른 엔드포인트로 전달하려면 `appsettings.json`의 `Webhook:RemoteHost`, `Webhook:Prefix`, `Webhook:MessageUpdateUrl` 값을 원하는 값으로 조합해 수정하면 된다.

--- a/WpfApp5/Configuration/AppConfiguration.cs
+++ b/WpfApp5/Configuration/AppConfiguration.cs
@@ -8,11 +8,23 @@ namespace WpfApp5.Configuration
 {
     public sealed class AppConfiguration
     {
+        private const string DefaultExporterHostname = "mytesthost123";
+
         public DatabaseConfiguration Database { get; init; }
         public RestApiConfiguration RestApi { get; init; }
         public WebhookConfiguration Webhook { get; init; }
+        public string ExporterHostname { get; set; } = DefaultExporterHostname;
 
-        // init Àü¿ë ¼Ó¼ºÀº »ı¼ºÀÚ¿¡¼­ ¼³Á¤ °¡´É
+            if (string.IsNullOrWhiteSpace(config.ExporterHostname))
+            {
+                config.ExporterHostname = DefaultExporterHostname;
+            }
+            else
+            {
+                config.ExporterHostname = config.ExporterHostname.Trim();
+            }
+
+        // init ì „ìš© ì†ì„±ì€ ìƒì„±ìì—ì„œ ì„¤ì • ê°€ëŠ¥
         public AppConfiguration()
         {
             Database = new DatabaseConfiguration();

--- a/WpfApp5/MainWindow.xaml.cs
+++ b/WpfApp5/MainWindow.xaml.cs
@@ -97,7 +97,7 @@ namespace KakaoPcLogger
             {
                 try
                 {
-                    _webhookService = new WebhookNotificationService(webhookEndpoint);
+                    _webhookService = new WebhookNotificationService(webhookEndpoint, _configuration.ExporterHostname);
                     _webhookService.Log += AppendLog;
                 }
                 catch (Exception ex)

--- a/WpfApp5/Services/WebhookNotificationService.cs
+++ b/WpfApp5/Services/WebhookNotificationService.cs
@@ -12,13 +12,19 @@ namespace KakaoPcLogger.Services
     {
         private readonly HttpClient _httpClient;
         private readonly Uri _endpoint;
+        private readonly string _host;
         private readonly JsonSerializerOptions _jsonOptions;
 
-        public WebhookNotificationService(string endpoint)
+        public WebhookNotificationService(string endpoint, string host)
         {
             if (string.IsNullOrWhiteSpace(endpoint))
             {
                 throw new ArgumentException("Webhook endpoint must be provided.", nameof(endpoint));
+            }
+
+            if (string.IsNullOrWhiteSpace(host))
+            {
+                throw new ArgumentException("Exporter host name must be provided.", nameof(host));
             }
 
             if (!Uri.TryCreate(endpoint, UriKind.Absolute, out var uri))
@@ -27,6 +33,7 @@ namespace KakaoPcLogger.Services
             }
 
             _endpoint = uri;
+            _host = host.Trim();
             _httpClient = new HttpClient();
             _jsonOptions = new JsonSerializerOptions
             {
@@ -52,6 +59,7 @@ namespace KakaoPcLogger.Services
             {
                 var payload = new
                 {
+                    host = _host,
                     chatRoom,
                     sender = message.Sender,
                     timestamp = message.LocalTs.ToString("yyyy-MM-dd HH:mm:ss"),

--- a/WpfApp5/appsettings.json
+++ b/WpfApp5/appsettings.json
@@ -1,4 +1,5 @@
 {
+  "ExporterHostname": "mytesthost123",
   "Database": {
     "Path": "data/kakao_chat_v2.db"
   },


### PR DESCRIPTION
## Summary
- add a configurable ExporterHostname with a default of `mytesthost123`
- include the exporter hostname when posting webhook notifications
- document the new request field and expose it in the default appsettings.json

## Testing
- not run (dotnet CLI not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc760a89e8832eb42115911c254c3f